### PR TITLE
Bump deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>no.ks.fiks.pom</groupId>
     <artifactId>fiks-ekstern-super-pom</artifactId>
-    <version>1.0.20</version>
+    <version>1.0.21</version>
   </parent>
   <groupId>no.ks.fiks</groupId>
   <artifactId>fiks-io-commons</artifactId>


### PR DESCRIPTION
- Bump junit-jupiter from 5.9.1 to 5.9.2
- Bump junit-platform-commons from 1.9.1 to 1.9.2
- Bump jackson-databind from 2.14.1 to 2.14.2
- Bump lombok from 1.18.24 to 1.18.26
- Bump maven-compiler-plugin from 3.10.1 to 3.11.0
- Bump maven-surefire-plugin from 2.22.2 to 3.0.0
- Bump amqp-client from 5.16.0 to 5.17.0
- Bump fiks-ekstern-super-pom from 1.0.20 to 1.0.21
