### PR TITLE
bumpet deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>no.ks.fiks.pom</groupId>
     <artifactId>fiks-ekstern-super-pom</artifactId>
-    <version>1.2.4</version>
+    <version>1.4.0</version>
   </parent>
   <groupId>no.ks.fiks</groupId>
   <artifactId>fiks-io-commons</artifactId>
@@ -24,16 +24,16 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
-    <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
+    <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
+    <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
 
-    <lombok.version>1.18.32</lombok.version>
-    <guava.version>33.2.1-jre</guava.version>
-    <jackson-databind.version>2.17.1</jackson-databind.version>
-    <amqp-client.version>5.21.0</amqp-client.version>
+    <lombok.version>1.18.38</lombok.version>
+    <guava.version>33.4.8-jre</guava.version>
+    <jackson-databind.version>2.19.2</jackson-databind.version>
+    <amqp-client.version>5.25.0</amqp-client.version>
 
-    <junit-platform-commons.version>1.10.2</junit-platform-commons.version>
-    <junit-jupiter.version>5.10.2</junit-jupiter.version>
+    <junit-platform-commons.version>1.13.3</junit-platform-commons.version>
+    <junit-jupiter.version>5.13.3</junit-jupiter.version>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
This pull request updates the `pom.xml` file to upgrade dependencies and plugins to newer versions, ensuring compatibility and access to the latest features and fixes.

### Dependency and Plugin Updates:

* Updated the parent POM version from `1.2.4` to `1.4.0` to align with the latest parent project changes. (`pom.xml`, [pom.xmlL8-R8](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L8-R8))
* Upgraded Maven plugin versions:
  - `maven-compiler-plugin` from `3.13.0` to `3.14.0`
  - `maven-surefire-plugin` from `3.2.5` to `3.5.3` (`pom.xml`, [pom.xmlL27-R36](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L27-R36))
* Updated library dependencies:
  - `lombok` from `1.18.32` to `1.18.38`
  - `guava` from `33.2.1-jre` to `33.4.8-jre`
  - `jackson-databind` from `2.17.1` to `2.19.2`
  - `amqp-client` from `5.21.0` to `5.25.0`
  - `junit-platform-commons` from `1.10.2` to `1.13.3`
  - `junit-jupiter` from `5.10.2` to `5.13.3` (`pom.xml`, [pom.xmlL27-R36](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L27-R36))